### PR TITLE
Lanczos3: Fix pi typo

### DIFF
--- a/assets/lanczos3.frag
+++ b/assets/lanczos3.frag
@@ -9,7 +9,7 @@ out vec3 fragColor;
 float lanczos3(float x)
 {
 	x = max(abs(x), 0.00001);
-	float val = x * 3.142592654;
+	float val = x * 3.141592654;
 	return sin(val) * sin(val / 3) / (val * val);
 }
 


### PR DESCRIPTION
I admit I'm not an expert on how the Lanczos algorithm works, but this certainly looks like a typo. If, for some reason, the original code is actually correct, a comment should probably be added documenting why.